### PR TITLE
Possibilidade de informar mais campos no Envio de Lote

### DIFF
--- a/pytrustnfe/nfse/paulistana/templates/EnvioLoteRPS.xml
+++ b/pytrustnfe/nfse/paulistana/templates/EnvioLoteRPS.xml
@@ -18,20 +18,20 @@
       <SerieRPS>{{ rps.serie }}</SerieRPS>
       <NumeroRPS>{{ rps.numero }}</NumeroRPS>
     </ChaveRPS>
-    <TipoRPS>RPS</TipoRPS>
+    <TipoRPS>{{ rps.tipo_rps | default('RPS') }}</TipoRPS>
     <DataEmissao>{{ rps.data_emissao }}</DataEmissao>
     <StatusRPS>N</StatusRPS>
-    <TributacaoRPS>T</TributacaoRPS>
+    <TributacaoRPS>{{ rps.tributacao_rps | default('T') }}</TributacaoRPS>
     <ValorServicos>{{ rps.valor_servico }}</ValorServicos>
     <ValorDeducoes>{{ rps.valor_deducao }}</ValorDeducoes>
-    <ValorPIS>0.00</ValorPIS>
-    <ValorCOFINS>0.00</ValorCOFINS>
-    <ValorINSS>0.00</ValorINSS>
-    <ValorIR>0.00</ValorIR>
-    <ValorCSLL>0.00</ValorCSLL>
+    <ValorPIS>{{ rps.valor_pis | default('0.00') }}</ValorPIS>
+    <ValorCOFINS>{{ rps.valor_cofins | default('0.00') }}</ValorCOFINS>
+    <ValorINSS>{{ rps.valor_inss | default('0.00') }}</ValorINSS>
+    <ValorIR>{{ rps.valor_ir | default('0.00') }}</ValorIR>
+    <ValorCSLL>{{ rps.valor_csll | default('0.00') }}</ValorCSLL>
     <CodigoServico>{{ rps.codigo_atividade }}</CodigoServico>
     <AliquotaServicos>{{ rps.aliquota_atividade }}</AliquotaServicos>
-    <ISSRetido>false</ISSRetido>
+    <ISSRetido>{{ rps.iss_retido | default('false') }}</ISSRetido>
     <CPFCNPJTomador>
         {% if rps.tomador.tipo_cpfcnpj == 1 -%}
            <CPF>{{ rps.tomador.cpf_cnpj }}</CPF>


### PR DESCRIPTION
Vários campos estavam preenchidos manualmente no template, adicionei a possibilidade de informá-los quando necessário, sem quebrar o comportamento antigo do sistema.