### PR TITLE
Update version lxml to 4.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml >= 3.5.0, < 5
+lxml >= 4.1.1, < 5
 coveralls
 Jinja2
 signxml


### PR DESCRIPTION
This error

ImportError: lxml.etree does not export expected C function adoptExternalDocument