### PR TITLE
Correção de erro de versão na tag nfeProc

### DIFF
--- a/pytrustnfe/utils.py
+++ b/pytrustnfe/utils.py
@@ -76,7 +76,7 @@ def _find_node(xml, node):
 
 def gerar_nfeproc(envio, recibo):
     NSMAP = {None: 'http://www.portalfiscal.inf.br/nfe'}
-    root = ET.Element("nfeProc", versao="3.10", nsmap=NSMAP)
+    root = ET.Element("nfeProc", versao="4.00", nsmap=NSMAP)
     docEnvio = ET.fromstring(envio)
     docRecibo = ET.fromstring(recibo)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from setuptools import setup, find_packages
 
-VERSION = "0.1.51"
+VERSION = "0.1.52"
 
 setup(
     name="PyTrustNFe",


### PR DESCRIPTION
Corrigido: número de versão da tag nfeProc de 3.10 para 4.00. A versão incorreta gerava erro de validação da nota fiscal enviada aos clientes, conforme testes realizados no site "https://www.sefaz.rs.gov.br/nfe/NFE-VAL.aspx"

Alterado: número de versão do pytrustnfe da versão 0.1.51 para 0.1.52