### PR TITLE
Correção do número de versão da tag nfeProc

### DIFF
--- a/pytrustnfe/utils.py
+++ b/pytrustnfe/utils.py
@@ -76,7 +76,7 @@ def _find_node(xml, node):
 
 def gerar_nfeproc(envio, recibo):
     NSMAP = {None: 'http://www.portalfiscal.inf.br/nfe'}
-    root = ET.Element("nfeProc", versao="3.10", nsmap=NSMAP)
+    root = ET.Element("nfeProc", versao="4.00", nsmap=NSMAP)
     parser = ET.XMLParser(encoding='utf-8')
     docEnvio = ET.fromstring(envio.encode('utf-8'), parser=parser)
     docRecibo = ET.fromstring(recibo.encode('utf-8'), parser=parser)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "0.10.1"
+VERSION = "0.10.2"
 
 
 setup(


### PR DESCRIPTION
Corrigido: número de versão da tag nfeProc de 3.10 para 4.00. A versão incorreta gerava erro de validação da nota fiscal enviada aos clientes, conforme testes realizados no site "https://www.sefaz.rs.gov.br/nfe/NFE-VAL.aspx"
Alterado: número de versão do pytrustnfe da versão 0.10.1 para 0.10.2