### PR TITLE
Update __init__.py

### DIFF
--- a/pytrustnfe/nfe/__init__.py
+++ b/pytrustnfe/nfe/__init__.py
@@ -135,10 +135,9 @@ def _send(certificado, method, **kwargs):
     port = next(iter(client.wsdl.port_types))
     first_operation = next(iter(client.wsdl.port_types[port].operations))
     
-    if kwargs['estado'] == '41':
-        namespaceNFe = xml.find(".//{http://www.portalfiscal.inf.br/nfe}NFe")
-        if namespaceNFe is not None:
-            namespaceNFe.set('xmlns', 'http://www.portalfiscal.inf.br/nfe')
+    namespaceNFe = xml.find(".//{http://www.portalfiscal.inf.br/nfe}NFe")
+    if namespaceNFe is not None:
+        namespaceNFe.set('xmlns', 'http://www.portalfiscal.inf.br/nfe')
             
     with client.settings(raw_response=True):
         response = client.service[first_operation](xml)

--- a/pytrustnfe/nfe/__init__.py
+++ b/pytrustnfe/nfe/__init__.py
@@ -134,6 +134,12 @@ def _send(certificado, method, **kwargs):
 
     port = next(iter(client.wsdl.port_types))
     first_operation = next(iter(client.wsdl.port_types[port].operations))
+    
+    if kwargs['estado'] == '41':
+        namespaceNFe = xml.find(".//{http://www.portalfiscal.inf.br/nfe}NFe")
+        if namespaceNFe is not None:
+            namespaceNFe.set('xmlns', 'http://www.portalfiscal.inf.br/nfe')
+            
     with client.settings(raw_response=True):
         response = client.service[first_operation](xml)
         response, obj = sanitize_response(response.text)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from setuptools import setup, find_packages
 
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 
 
 setup(


### PR DESCRIPTION
 A biblioteca ZEEP remove namespaces duplicadas. O estado do PR exige a mesma namespace em duas tags, devemos adicionar a mesma na tag NFe antes do envio ao sefaz Paraná.
Não sei se é a melhor solução para o padrão PyTrustNFe mas segue minha pequena contribuição.