### PR TITLE
[FIX] Ajusta os namespaces para envio de NFe no estado do PR

### DIFF
--- a/pytrustnfe/Servidores.py
+++ b/pytrustnfe/Servidores.py
@@ -375,8 +375,8 @@ UFMT = {
         WS_NFE_INUTILIZACAO: 'nfews/v2/services/NfeInutilizacao4?wsdl',
         WS_NFE_CONSULTA: 'nfews/v2/services/NfeConsulta4?wsdl',
         WS_NFE_SITUACAO: 'nfews/v2/services/NfeStatusServico4?wsdl',
-        WS_NFE_RECEPCAO_EVENTO: 'nfews/v2/services/CadConsultaCadastro4?wsdl',
-        WS_NFE_AUTORIZACAO: 'nfews/v2/services/RecepcaoEvento4?wsdl',
+        WS_NFE_RECEPCAO_EVENTO: 'nfews/v2/services/RecepcaoEvento4?wsdl',
+        WS_NFE_AUTORIZACAO: 'nfews/v2/services/NfeAutorizacao4?wsdl',
         WS_NFE_RET_AUTORIZACAO: 'nfews/v2/services/NfeRetAutorizacao4?wsdl',
         WS_NFE_CADASTRO: 'nfews/v2/services/CadConsultaCadastro4?wsdl',
     }

--- a/pytrustnfe/nfe/__init__.py
+++ b/pytrustnfe/nfe/__init__.py
@@ -135,6 +135,11 @@ def _send(certificado, method, **kwargs):
     port = next(iter(client.wsdl.port_types))
     first_operation = [x for x in iter(
         client.wsdl.port_types[port].operations) if "Zip" not in x][0]
+
+    namespaceNFe = xml.find(".//{http://www.portalfiscal.inf.br/nfe}NFe")
+    if namespaceNFe is not None:
+        namespaceNFe.set('xmlns', 'http://www.portalfiscal.inf.br/nfe')
+
     with client.settings(raw_response=True):
         response = client.service[first_operation](xml)
         response, obj = sanitize_response(response.text)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 
 
 setup(


### PR DESCRIPTION
A biblioteca ZEEP remove namespaces duplicadas. O estado do PR exige a mesma namespace em duas tags, devemos adicionar a mesma na tag NFe antes do envio ao sefaz Paraná.