### PR TITLE
Padronizado as versões do setup.py e do requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ Jinja2
 signxml
 urllib3 >= 1.22
 suds-jurko >= 0.6
-suds-jurko-requests >= 1.1
-defusedxml >= 0.4.1, < 1
+suds-jurko-requests >= 1.2
+defusedxml >= 0.7.1, < 1
 eight >= 0.3.0, < 1
 cryptography >= 1.8, < 3
 pyOpenSSL >= 16.0.0, < 18

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ later (LGPLv2+)",
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     install_requires=[
-        'urllib3',
-        'xmlsec==1.3.3',  # apt update;apt install libxmlsec1-dev pkg-config -y
+        'urllib3 >= 1.22',
+        'xmlsec >= 1.3.3',  # apt update;apt install libxmlsec1-dev pkg-config -y
         'Jinja2 >= 2.8',
         'pyOpenSSL >= 16.0.0, < 18',
         'signxml >= 2.4.0',


### PR DESCRIPTION
As versões que estão no setup.py estão diferentes das versões do requirements.txt, atualizei algumas que achei necessário deixando idênticas e que geraram erros durante a instalação da lib na versão atual, principalmente a xmlsec e a defusexml.