### PR TITLE
Alterando url de homologação da nota carioca

### DIFF
--- a/pytrustnfe/nfse/carioca/__init__.py
+++ b/pytrustnfe/nfse/carioca/__init__.py
@@ -27,9 +27,9 @@ def _render(certificado, method, **kwargs):
 def _send(certificado, method, **kwargs):
     base_url = ''
     if kwargs['ambiente'] == 'producao':
-        base_url = 'https://notacarioca.rio.gov.br/WSNacional/nfse.asmx?wsdl'
+        base_url = 'https://notacarioca.rio.gov.br/WSNacional/nfse.asmx?wsdl'        
     else:
-        base_url = 'https://homologacao.notacarioca.rio.gov.br/WSNacional/nfse.asmx?wsdl'  # noqa
+        base_url = "https://notacariocahom.rio.gov.br/WSNacional/nfse.asmx?wsdl" # noqa
 
     xml_send = kwargs["xml"].decode('utf-8')
     cert, key = extract_cert_and_key_from_pfx(


### PR DESCRIPTION
…o.gov.br

Houve alteração no endpoint de homologação para https://notacariocahom.rio.gov.br seguindo o comunicado abaixo:

https://notacarioca.rio.gov.br/mensageria/lermensagem.aspx?mensagem=3585222